### PR TITLE
Get AssemblyName of not provided

### DIFF
--- a/src/K8sOperator.NET/Builder/OperatorHostBuilder.cs
+++ b/src/K8sOperator.NET/Builder/OperatorHostBuilder.cs
@@ -87,7 +87,7 @@ internal class OperatorApplicationBuilder : IOperatorApplicationBuilder, IContro
     private void ConfigureMetadata()
     {
         var operatorName = Assembly.GetEntryAssembly()?.GetCustomAttribute<OperatorNameAttribute>()
-            ?? OperatorNameAttribute.Default;
+            ?? new OperatorNameAttribute(Assembly.GetEntryAssembly()?.GetName()?.Name);
         
         var dockerImage = Assembly.GetEntryAssembly()?.GetCustomAttribute<DockerImageAttribute>() 
             ?? DockerImageAttribute.Default;

--- a/src/K8sOperator.NET/Metadata/OperatorNameMetadata.cs
+++ b/src/K8sOperator.NET/Metadata/OperatorNameMetadata.cs
@@ -19,7 +19,7 @@ public interface IOperatorNameMetadata
 /// </summary>
 /// <param name="name"></param>
 [AttributeUsage(AttributeTargets.Assembly)]
-public class OperatorNameAttribute(string name) : Attribute, IOperatorNameMetadata
+public class OperatorNameAttribute(string? name) : Attribute, IOperatorNameMetadata
 {
     /// <summary>
     /// Default value of the attribute
@@ -27,7 +27,7 @@ public class OperatorNameAttribute(string name) : Attribute, IOperatorNameMetada
     public static OperatorNameAttribute Default => new("operator");
 
     /// <inheritdoc/>
-    public string OperatorName => name;
+    public string OperatorName => name ?? Default.OperatorName;
 
     /// <inheritdoc />
     public override string ToString()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced operator configuration to improve reliability. The operator name is now dynamically determined—defaulting to the entry assembly's name when no custom value is provided—and gracefully handles unspecified values through a robust fallback mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->