### PR TITLE
Downgrades docfx version and allows compilation errors

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "docfx": {
-      "version": "2.78.4",
+      "version": "2.77.0",
       "commands": [
         "docfx"
       ]

--- a/docfx.json
+++ b/docfx.json
@@ -31,7 +31,8 @@
       {
         "src": [
           {
-            "files": ["src/**/*.csproj"]
+            "files": ["src/**/*.csproj"],
+            "exclude": []
           }
         ],
         "dest": "docs/api",
@@ -42,7 +43,7 @@
         "namespaceLayout": "flattened",
         "memberLayout": "samePage",
         "EnumSortOrder": "alphabetic",
-        "allowCompilationErrors": false
+        "allowCompilationErrors": true
       }
     ]
   }


### PR DESCRIPTION
Downgrades the docfx version to 2.77.0 to avoid potential issues.
Enables the allowCompilationErrors option in docfx to prevent build failures. This allows the documentation generation to continue even if there are compilation errors in the project.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Downgraded documentation tool version to optimize compatibility.
  * Updated documentation build configuration to allow compilation errors during processing and adjusted exclusion rules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->